### PR TITLE
fix folder scanner buffer deadlock

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Package",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/m3ugen/main.go",
+      "args": [""]
+    }
+  ]
+}

--- a/config.go
+++ b/config.go
@@ -29,6 +29,8 @@ type Config struct {
 	ScanFolderWorkers int `json:"scan_folder_workers"`
 	// Number of workers filtering the files.
 	ReceiveFilesWorkers int `json:"receive_files_workers"`
+	// Buffer size of the various Go channels used while scanning.
+	ChannelsBufferSize int `json:"channels_buffer_size"`
 }
 
 // NewDefaultConfig creates a configuration with default values.
@@ -40,9 +42,10 @@ func NewDefaultConfig() *Config {
 		ScanFolders:         nil,
 		Extensions:          nil,
 		RandomizeList:       false,
-		MaximumEntries:      -1,
+		MaximumEntries:      0, // no maximum
 		ScanFolderWorkers:   4,
-		ReceiveFilesWorkers: 1,
+		ReceiveFilesWorkers: 4,
+		ChannelsBufferSize:  1024,
 	}
 }
 

--- a/pkg/dynchan/dynChan.go
+++ b/pkg/dynchan/dynChan.go
@@ -1,0 +1,50 @@
+package dynchan
+
+func New[T any]() (chan<- T, <-chan T) {
+	in := make(chan T)
+	out := make(chan T)
+	go dynChanLoop(in, out)
+	return in, out
+}
+
+func NewBuffered[T any](bufferSize uint) (chan<- T, <-chan T) {
+	in := make(chan T, bufferSize)
+	out := make(chan T, bufferSize)
+	go dynChanLoop(in, out)
+	return in, out
+}
+
+// Credits: Inspired from the following sites and posts, although modified, fixed and completed.
+// - https://medium.com/capital-one-tech/building-an-unbounded-channel-in-go-789e175cd2cd
+// - https://stackoverflow.com/questions/41906146/why-go-channels-limit-the-buffer-size
+func dynChanLoop[T any](in chan T, out chan T) {
+	var nextValue T
+	var inQueue []T
+
+	defer close(out)
+
+	for len(inQueue) > 0 || in != nil {
+		if len(inQueue) == 0 {
+			// Wait for a new value (nothing to serve, no need to sync between in and out channels with `select`).
+			valueIn, ok := <-in
+			if !ok {
+				return // input channel is closed & there is no value left to serve: done
+			}
+			inQueue = append(inQueue, valueIn)
+		}
+
+		// At this point, there is at least 1 value in the queue.
+		// Select on either new values coming in or requests to send next value in queue.
+		nextValue = inQueue[0]
+		select {
+		case valueIn, ok := <-in:
+			if !ok {
+				in = nil // causes `in` to no longer be read by `select` statements
+			} else {
+				inQueue = append(inQueue, valueIn)
+			}
+		case out <- nextValue:
+			inQueue = inQueue[1:] // pop first element out
+		}
+	}
+}


### PR DESCRIPTION
When there are more folders than the buffer of `folderToScanChan`, a deadlock occurs.

Introducing `dynchan` to fix this issue. Also re-worked some of the go-routine-ing for better completion sync/join.